### PR TITLE
Update README.md

### DIFF
--- a/burp_extension/README.md
+++ b/burp_extension/README.md
@@ -6,8 +6,10 @@ It does so by looking for the string "autochrome/[XXXX]" in the User-Agent heade
 
 # Installation
 
-1. Run Burp.  Under Extender => APIs, click "Save interface files".
-1. Copy the files to `src/burp`.
+1. `cd` into the `autochrome/burp_extension/src` directory.
+1. `cp burp/BurpExtender.java ./`
+1. Run Burp, under Extender => APIs, click "Save interface files", save them to `src/burp/`.
+1. `cp BurpExtender.java burp/`
 1. `javac burp/BurpExtender.java`
 1. jar cf autochrome-useragenttag.jar burp/BurpExtender.class com/nccgroup/autochrome/useragenttag/*.class
 1. In Burp, go to Extender => Extensions.


### PR DESCRIPTION
Updates README.md for extension to include instructions for getting around 'The directory selected is not empty' error when saving Burp interface files.