### PR TITLE
Adding option to specify a proxy host

### DIFF
--- a/autochrome.rb
+++ b/autochrome.rb
@@ -53,6 +53,10 @@ def parse_options(arg_list)
       options[:clobber] = true
     end
 
+    opts.on("-p", "--proxy-host HOST", "Proxy host") do |p|
+      options[:proxyhost] = p
+    end
+
     opts.on("-p", "--proxy-base PORT", "Local proxy base port") do |p|
       options[:proxybase] = p.to_i
     end

--- a/lib/processor/linux.rb
+++ b/lib/processor/linux.rb
@@ -42,7 +42,7 @@ opts = [
   "--disable-web-resources",
   "--safebrowsing-disable-auto-update",
   "--safebrowsing-disable-download-protection",
-  "--proxy-server=localhost:#{@proxyport}",
+  "--proxy-server=#{@proxyhost}:#{@proxyport}",
   "--user-data-dir=#{@profiledir}",
 ]
 opts.push *ARGV

--- a/lib/processor/macosx.rb
+++ b/lib/processor/macosx.rb
@@ -47,7 +47,7 @@ opts = [
   "--safebrowsing-disable-auto-update",
   "--safebrowsing-disable-download-protection",
   "--use-mock-keychain",
-  "--proxy-server=localhost:#{@proxyport}",
+  "--proxy-server=#{@proxyhost}:#{@proxyport}",
   "--user-data-dir=#{@profiledir}",
 ]
 opts.push *ARGV

--- a/lib/processor/unix.rb
+++ b/lib/processor/unix.rb
@@ -10,6 +10,7 @@ class ChromeProcessor::UNIX < ChromeProcessor
     @installdir = File.expand_path(self.class::FinalAppName, to)
     @profiledir = opts[:data_dir]
     @clobber = opts[:clobber]
+    @proxyhost = opts[:proxyhost] || 'localhost'
     @proxyport = opts[:proxybase] || 8080
   end
 


### PR DESCRIPTION
I've added an option (based on proxy-base) to allow for alternate specification of a proxy host.  I thought this could be useful for instances where the burp install might be running on another host.

In my usecase I'm running autochrome in a docker container, so it's handy to be able to specify a different proxy host.