### PR TITLE
build every extensions in src without adding them to the exts array

### DIFF
--- a/build_extensions.rb
+++ b/build_extensions.rb
@@ -93,7 +93,7 @@ THEME_COLORS.each do |color_name,hue|
 end
 
 # Build extensions
-exts = ['autochrome_junk_drawer', 'settingsreset']
+exts = Dir.entries(EXT_SOURCE_DIR).delete_if { |d| d =~ /\.\.?/ };
 exts.each do |ext|
   build_extension(options, "#{EXT_SOURCE_DIR}/#{ext}", "#{EXT_OUTPUT_DIR}/#{ext}.crx")
 end


### PR DESCRIPTION
Hello,
I make a pull request that changes that when an user add an extension is data/extension_source/ directory the build_extensions.rb script will compile it without adding them to the following array : 
```ruby
exts = ['autochrome_junk_drawer', 'settingsreset']
```
