### PR TITLE
Fix extension install

### DIFF
--- a/lib/auto_chrome/chrome_extension.rb
+++ b/lib/auto_chrome/chrome_extension.rb
@@ -4,23 +4,44 @@ require "open3"
 
 class AutoChrome::ChromeExtension
   attr_reader :path, :id, :key, :manifest, :version
+
   def initialize(crx_path)
     @path = crx_path
-
-    data = File.read(@path, mode: 'rb')
-    key_file = File.dirname(path) + "/" + File.basename(@path, ".crx") + ".pub"
-    if !File.exists?(key_file)
-      raise "No key file found for extension #{path}"
-    end
-    @key = File.read(key_file)
-    @id = Digest::SHA256.hexdigest(key)[0...32].tr('0-9a-f', 'a-p')
 
     # use open3 to suppress unzip warnings for unexpected crx headers
     json, _, _ = Open3.capture3('unzip', '-qc', @path, 'manifest.json')
 
     @manifest = JSON.parse(json, symbolize_names: true)
-    @manifest[:key] = Base64.encode64(@key).gsub(/\s/, '')
 
-    @version = @manifest[:version]
+    key_file = File.dirname(path) + "/" + File.basename(@path, ".crx") + ".pub"
+    unless File.exists?(key_file)
+      if @manifest.dig(:key) != nil
+        puts "[---] Reading key from manifest, this might not work..."
+        @key = @manifest[:key]
+        @id = Digest::SHA256.hexdigest(Base64.decode64(@key))[0...32].tr('0-9a-f', 'a-p')
+      else
+        raise "No key file or key in manifest found for extension #{path}"
+      end
+    else
+      @key = File.read(key_file)
+      @id = Digest::SHA256.hexdigest(key)[0...32].tr('0-9a-f', 'a-p')
+      @manifest[:key] = Base64.encode64(@key).gsub(/\s/, '')
+    end
+
+    if @manifest.dig(:id) != nil
+      @id = @manifest[:id]
+    else
+      if :id == nil || id.to_s.strip.empty?
+        raise "No id found for extension #{path}!"
+      end
+    end
+
+    if @manifest.dig(:version) != nil
+      @version = @manifest[:version]
+    else
+      if :version == nil
+        raise "No version found for extension #{path}!"
+      end
+    end
   end
 end

--- a/lib/auto_chrome/chrome_extension.rb
+++ b/lib/auto_chrome/chrome_extension.rb
@@ -14,7 +14,7 @@ class AutoChrome::ChromeExtension
     @manifest = JSON.parse(json, symbolize_names: true)
 
     key_file = File.dirname(path) + "/" + File.basename(@path, ".crx") + ".pub"
-    unless File.exists?(key_file)
+    if !File.exist?(key_file)
       if @manifest.dig(:key) != nil
         puts "[---] Reading key from manifest, this might not work..."
         @key = @manifest[:key]

--- a/lib/auto_chrome/profile_builder.rb
+++ b/lib/auto_chrome/profile_builder.rb
@@ -126,7 +126,11 @@ class AutoChrome::ProfileBuilder
 
     # bypass extension confirmation prompts
     profiles.each do |p|
-      p.secure_prefs["extensions.settings.#{crx.id}"] = {ack_external: true}
+      p.secure_prefs["extensions.settings.#{crx.id}"] = {
+          disable_reasons: 0,
+          ack_external: true,
+          state: 1 # this will soon be deprecated, better to use disable_reasons right away
+      }
     end
     #XXX this will break if we call add_extension multiple times with the same
     #extension and different profiles


### PR DESCRIPTION
Hi, 

as mentioned in #28 I'm trying to get the installation of extensions without a `.pub` file to work (using the public key in the `manifest.json`).

The modification I made will use the `key` property of the manifest in case there is no `.pub` file available.

Unfortunately there is something buggy and while the extension (`.crx`) and the accompanying `.json` file are copied into the `External Extensions` folder, the extension doesn't show up in `chrome://extensions`.
