### PR TITLE
Support M1 Mac

### DIFF
--- a/data/default_prefs.yaml
+++ b/data/default_prefs.yaml
@@ -47,6 +47,9 @@
       "eacc8c3ad0b50bd698ef8752d5ee24b6": null
     }
   },
+  "omnibox": {
+    "prevent_url_elisions": true
+  },
   "profile": {
     "password_manager_enabled": false,
     "default_content_settings": {

--- a/lib/auto_chrome/fetcher.rb
+++ b/lib/auto_chrome/fetcher.rb
@@ -17,6 +17,7 @@ class AutoChrome::Fetcher
   TypeZipMap = {
     "Linux_x64" => "chrome-linux.zip",
     "Mac" => "chrome-mac.zip",
+    "Mac_Arm" => "chrome-mac.zip",
     "Win" => "chrome-win32.zip",
     "Win_x64" => "chrome-win32.zip",
   }
@@ -100,8 +101,14 @@ class AutoChrome::Fetcher
 
       case os
       when /darwin/
-        puts "[???] Detected OS X"
-        "Mac"
+        arch = %x( arch ) # Note: this will return x86 on M1 if the shell process was run in Rosetta
+        if /arm64/.match(arch)
+          puts "[???] Detected OS X (Apple Silicon)"
+          "Mac_Arm"
+        else
+          puts "[???] Detected OS X (Intel)"
+          "Mac"
+        end
       when /linux/
         # Chromium only runs on 64-bit Linux, check this.
         cpu = RbConfig::CONFIG['host_cpu']

--- a/lib/auto_chrome/prefs.rb
+++ b/lib/auto_chrome/prefs.rb
@@ -42,8 +42,8 @@ class AutoChrome
 
     def uuid
       @uuid ||= @opts[:uuid] || case @opts[:os_type]
-      when 'Mac'
-        if AutoChrome::Fetcher.guess_type != 'Mac'
+      when 'Mac', 'Mac_Arm'
+        if AutoChrome::Fetcher.guess_type != 'Mac' && AutoChrome::Fetcher.guess_type != 'Mac_Arm'
           raise "can't determine UUID for MacOS secure prefs when not on a Mac"
         end
         s = `ioreg -rd1 -c IOPlatformExpertDevice`

--- a/lib/auto_chrome/profile_builder.rb
+++ b/lib/auto_chrome/profile_builder.rb
@@ -196,7 +196,7 @@ class AutoChrome::ProfileBuilder
 
   def self.get_default_directory(type)
     case type
-    when "Mac"
+    when "Mac", "Mac_Arm"
       default = "~/Library/Application Support/Chromium"
     when "Linux_x64"
       default = "~/.config/autochrome"

--- a/lib/chromecache.rb
+++ b/lib/chromecache.rb
@@ -32,7 +32,7 @@ class ChromeCache
 
   def self.new_from_type(type)
     case self.get_host(type)
-    when "Mac"
+    when "Mac", "Mac_Arm"
       MacChromeCache.new
     when "Linux_x64"
       XDGChromeCache.new

--- a/lib/processor/chrome.rb
+++ b/lib/processor/chrome.rb
@@ -43,7 +43,7 @@ class ChromeProcessor
 
   def self.new_from_type(opts={})
     case opts[:os_type]
-    when "Mac"
+    when "Mac", "Mac_Arm"
       ChromeProcessor::MacOSX.new(opts)
     when "Linux_x64"
       ChromeProcessor::Linux.new(opts)


### PR DESCRIPTION
Previously, `autochrome` would download the x86 version of Chromium on Apple silicon. This PR adds checks to ensure the ARM version of Chromium is installed on M1 devices.

Running `autochrome` in a shell operating within Rosetta will install the x86 version of Chromium; a logical outcome.

This PR also incorporates #31  from @xorcat.