### PR TITLE
Added compatibility with Ruby >=3.2.0

### DIFF
--- a/autochrome.rb
+++ b/autochrome.rb
@@ -5,6 +5,19 @@ if RUBY_VERSION < '2.0'
   exit 1
 end
 
+if RUBY_VERSION >= '3.2.0'
+  STDERR.puts "Your version of ruby is >= 3.2.0, applying monkeypatch to File and Dir (see https://bugs.ruby-lang.org/issues/17391)"
+
+  class << File
+    alias_method :exists?, :exist?
+  end
+
+  class << Dir
+    alias_method :exists?, :exist?
+  end
+
+end
+
 require 'optparse'
 
 $: << File.join(File.dirname(__FILE__), 'lib')


### PR DESCRIPTION
Added monkeypatch to enable compatibility with Ruby >= 3.2.0 without … breaking support for <3.2.0

As per https://bugs.ruby-lang.org/issues/17391 File.exists and Dir.exists were removed (now just exist) with Ruby versions >= 3.2.0.

In order to maintain compability with all versions an alias was added for Dir.exist(s) and File.exist(s).