### PR TITLE
Fix --list-themes and colorized User-Agent

### DIFF
--- a/autochrome.rb
+++ b/autochrome.rb
@@ -78,7 +78,7 @@ def parse_options(arg_list)
     end
 
     opts.on_tail("--list-themes", "List included themes") do
-      pathglob = File.join(ProfileBuilder::BuiltinThemeDirectory, "*.crx")
+      pathglob = File.join(AutoChrome::ProfileBuilder::BuiltinThemeDirectory, "*.crx")
       themes = Dir[pathglob].select {|f| File.file?(f)}.map do |f|
         File.basename(f).gsub("\.crx", "")
       end

--- a/data/bookmarks.yaml
+++ b/data/bookmarks.yaml
@@ -29,7 +29,11 @@
         }
       ],
       "type": "folder"
-    }
+    },
+    "synced": {
+      "children": [  ],
+      "type": "folder"
+      }
   },
   "version": 1
 }


### PR DESCRIPTION
Hi, two bug fixes in this PR.

1. the `--list-themes` was broken because of a missing module name. See error below

```
$ ruby /Users/louis.dionmarcil/Tools/autochrome/autochrome.rb --list-themes
Ignoring http_parser.rb-0.8.0 because its extensions are not built. Try: gem pristine http_parser.rb --version 0.8.0
Traceback (most recent call last):
        7: from /Users/louis.dionmarcil/Tools/autochrome/autochrome.rb:102:in `<main>'
        6: from /Users/louis.dionmarcil/Tools/autochrome/autochrome.rb:95:in `parse_options'
        5: from /Users/louis.dionmarcil/.rbenv/versions/2.6.0/lib/ruby/2.6.0/optparse.rb:1553:in `order'
        4: from /Users/louis.dionmarcil/.rbenv/versions/2.6.0/lib/ruby/2.6.0/optparse.rb:1562:in `order!'
        3: from /Users/louis.dionmarcil/.rbenv/versions/2.6.0/lib/ruby/2.6.0/optparse.rb:1568:in `parse_in_order'
        2: from /Users/louis.dionmarcil/.rbenv/versions/2.6.0/lib/ruby/2.6.0/optparse.rb:1568:in `catch'
        1: from /Users/louis.dionmarcil/.rbenv/versions/2.6.0/lib/ruby/2.6.0/optparse.rb:1582:in `block in parse_in_order'
/Users/louis.dionmarcil/Tools/autochrome/autochrome.rb:81:in `block (2 levels) in parse_options': uninitialized constant ProfileBuilder (NameError)
```

Fixed it in commit 08be53b1911cc64b4d5038cfc76571e12e4b7861.

2. The User-Agent headers were not properly sending the profile's colour (ie `User-Agent: Mozilla... autochrome/red`). This was due to the profile Bookmarks not being generated properly, and the User-Agent relying on Bookmarks to get the current profile's colour. I fixed the structure of [data/bookmarks.yaml](https://github.com/nccgroup/autochrome/blob/master/data/bookmarks.yaml) by adding the (seemingly) now necessary "synced" JSON key.